### PR TITLE
Fix config files for GBA overlays

### DIFF
--- a/overlays/GBA/edgetoedge_landscape.cfg
+++ b/overlays/GBA/edgetoedge_landscape.cfg
@@ -1,28 +1,25 @@
-# "name" : "Edge to Edge Landscape GBA"
-# "author" : "Volkan Turkut"
-
 overlays = 1
-
+overlay0_name = "edgetoedge_landscape"
+overlay0_aspect_ratio = 2.1650672
 overlay0_overlay = edgetoedge_landscape.png
-overlay0_name = edgetoedge_landscape
+overlay0_normalized = true
 overlay0_full_screen = true
-
-# Edge to Egde Landscape
-
+overlay0_block_x_separation = true
+overlay0_block_y_separation = true
 overlay0_descs = 16
-overlay0_desc0  = "left,100,1300,rect,50,50"
-overlay0_desc1  = "right,280,1300,rect,50,50"
-overlay0_desc2  = "up,195,1200,rect,50,50"
-overlay0_desc3  = "down,195,1395,rect,50,50"
-overlay0_desc4 = "left|up,98,1198,rect,34,34"
-overlay0_desc5 = "left|down,98,1398,rect,34,34"
-overlay0_desc6 = "right|up,290,1200,rect,34,34"
-overlay0_desc7 = "right|down,290,1395,rect,34,34"
-overlay0_desc8 = "b,770,1330,radial,74,74"
-overlay0_desc9 = "a,965,1235,radial,74,74"
-overlay0_desc10 = "a|b,775,1105,radial,74,74"
-overlay0_desc11 = "l,965,1235,radial,74,74"
-overlay0_desc12 = "r,965,1235,radial,74,74"
-overlay0_desc13  = "select,370,1585,rect,74,74"
-overlay0_desc14  = "start,570,1585,rect,74,74"
-overlay0_desc15 = "menu_toggle,205,35,rect,120,30"
+overlay0_desc0  = "left,0.0714,0.7435,rect,0.03941,0.08536"
+overlay0_desc1  = "right,0.2007,0.7435,rect,0.03941,0.08536"
+overlay0_desc2  = "up,0.1365,0.60385,rect,0.03941,0.08536"
+overlay0_desc3  = "down,0.1365,0.88329,rect,0.03941,0.08536"
+overlay0_desc4 = "left|up,0.068,0.5972,rect,0.02956,0.06402"
+overlay0_desc5 = "left|down,0.068,0.89216,rect,0.02956,0.06402"
+overlay0_desc6 = "right|up,0.2043,0.5972,rect,0.02956,0.06402"
+overlay0_desc7 = "right|down,0.2043,0.88994,rect,0.02956,0.06402"
+overlay0_desc8 = "b,0.82341,0.86111,radial,0.04927,0.10670"
+overlay0_desc9 = "a,0.91656,0.70587,radial,0.04927,0.10670"
+overlay0_desc10 = "a|b,0.92765,0.90769,rect,0.04604,0.07825"
+overlay0_desc11 = "l,0.07517,0.07825,rect,0.07517,0.07825"
+overlay0_desc12 = "r,0.92602,0.07603,rect,0.07513,0.0782"
+overlay0_desc13  = "select,0.44639,0.9343,rect,0.04762,0.05385"
+overlay0_desc14  = "start,0.55728,0.9343,rect,0.04762,0.05385"
+overlay0_desc15 = "menu_toggle,0.50184,0.0605,rect,0.05318,0.06272"

--- a/overlays/GBA/edgetoedge_portrait.cfg
+++ b/overlays/GBA/edgetoedge_portrait.cfg
@@ -1,27 +1,24 @@
-# "name" : "Edge to Edge Portrait GBA"
-# "author" : "Volkan Turkut"
-
 overlays = 1
-
 overlay0_overlay = edgetoedge_portrait.png
-overlay0_name = edgetoedge_portrait
+overlay0_aspect_ratio = 0.4618794
+overlay0_normalized = true
+overlay0_name = "edgetoedge_portrait"
 overlay0_full_screen = true
-
-# Edge to Egde Portrait
-
+overlay0_block_x_separation = true
+overlay0_block_y_separation = true
 overlay0_descs = 15
-overlay0_desc0  = "left,100,1300,rect,50,50"
-overlay0_desc1  = "right,280,1300,rect,50,50"
-overlay0_desc2  = "up,195,1200,rect,50,50"
-overlay0_desc3  = "down,195,1395,rect,50,50"
-overlay0_desc4 = "left|up,98,1198,rect,34,34"
-overlay0_desc5 = "left|down,98,1398,rect,34,34"
-overlay0_desc6 = "right|up,290,1200,rect,34,34"
-overlay0_desc7 = "right|down,290,1395,rect,34,34"
-overlay0_desc8 = "b,770,1330,radial,74,74"
-overlay0_desc9 = "a,965,1235,radial,74,74"
-overlay0_desc10 = "l,965,1235,radial,74,74"
-overlay0_desc11 = "r,965,1235,radial,74,74"
-overlay0_desc12  = "select,370,1585,rect,74,74"
-overlay0_desc13  = "start,570,1585,rect,74,74"
-overlay0_desc14 = "menu_toggle,205,35,rect,120,30"
+overlay0_desc0  = "left,0.09597,0.78000,rect,0.08,0.03695"
+overlay0_desc1  = "right,0.3599,0.78000,rect,0.08,0.03695"
+overlay0_desc2  = "up,0.22683,0.71918,rect,0.08,0.03695"
+overlay0_desc3  = "down,0.22683,0.84115,rect,0.08,0.03695"
+overlay0_desc4 = "left|up,0.0915,0.71696,rect,0.06,0.02771"
+overlay0_desc5 = "left|down,0.0915,0.84337,rect,0.06,0.02771"
+overlay0_desc6 = "right|up,0.36434,0.71696,rect,0.06,0.02771"
+overlay0_desc7 = "right|down,0.36434,0.84337,rect,0.06,0.02771"
+overlay0_desc8 = "b,0.64821,0.82563,radial,0.1,0.04619"
+overlay0_desc9 = "a,0.85224,0.73914,radial,0.1,0.04619"
+overlay0_desc10 = "l,0.14478,0.62160,rect,0.147,0.02500"
+overlay0_desc11 = "r,0.85224,0.62160,rect,0.147,0.02500"
+overlay0_desc12  = "select,0.422,0.91656,radial,0.05,0.02309"
+overlay0_desc13  = "start,0.58168,0.91656,radial,0.05,0.02309"
+overlay0_desc14 = "menu_toggle,0.05829,0.91877,radial,0.05,0.02309"

--- a/overlays/GBA/landscape.cfg
+++ b/overlays/GBA/landscape.cfg
@@ -1,28 +1,25 @@
-# "name" : "Landscape GBA"
-# "author" : "Volkan Turkut"
-
 overlays = 1
-
 overlay0_overlay = landscape.png
-overlay0_name = landscape
+overlay0_aspect_ratio = 1.7783109
+overlay0_normalized = true
+overlay0_name = "landscape"
 overlay0_full_screen = true
-
-# Landscape
-
+overlay0_block_x_separation = true
+overlay0_block_y_separation = true
 overlay0_descs = 16
-overlay0_desc0  = "left,100,1300,rect,50,50"
-overlay0_desc1  = "right,280,1300,rect,50,50"
-overlay0_desc2  = "up,195,1200,rect,50,50"
-overlay0_desc3  = "down,195,1395,rect,50,50"
-overlay0_desc4 = "left|up,98,1198,rect,34,34"
-overlay0_desc5 = "left|down,98,1398,rect,34,34"
-overlay0_desc6 = "right|up,290,1200,rect,34,34"
-overlay0_desc7 = "right|down,290,1395,rect,34,34"
-overlay0_desc8 = "b,770,1330,radial,74,74"
-overlay0_desc9 = "a,965,1235,radial,74,74"
-overlay0_desc10 = "a|b,775,1105,radial,74,74"
-overlay0_desc11 = "l,965,1235,radial,74,74"
-overlay0_desc12 = "r,965,1235,radial,74,74"
-overlay0_desc13  = "select,370,1585,rect,74,74"
-overlay0_desc14  = "start,570,1585,rect,74,74"
-overlay0_desc15 = "menu_toggle,205,35,rect,120,30"
+overlay0_desc0  = "left,0.06494,0.7435,rect,0.04800,0.08536"
+overlay0_desc1  = "right,0.22240,0.7435,rect,0.04800,0.08536"
+overlay0_desc2  = "up,0.14420,0.60385,rect,0.04800,0.08536"
+overlay0_desc3  = "down,0.14420,0.88329,rect,0.04800,0.08536"
+overlay0_desc4 = "left|up,0.061,0.5972,rect,0.03600,0.06402"
+overlay0_desc5 = "left|down,0.061,0.89216,rect,0.03600,0.06402"
+overlay0_desc6 = "right|up,0.22683,0.5972,rect,0.03600,0.06402"
+overlay0_desc7 = "right|down,0.22683,0.88994,rect,0.03600,0.06402"
+overlay0_desc8 = "b,0.80789,0.86111,radial,0.06000,0.10670"
+overlay0_desc9 = "a,0.92099,0.70587,radial,0.06000,0.10670"
+overlay0_desc10 = "a|b,0.9343,0.90769,rect,0.05607,0.07825"
+overlay0_desc11 = "l,0.09155,0.07825,rect,0.09155,0.07825"
+overlay0_desc12 = "r,0.90990,0.07603,rect,0.09150,0.0782"
+overlay0_desc13  = "select,0.43087,0.9343,rect,0.05800,0.05385"
+overlay0_desc14  = "start,0.57059,0.9343,rect,0.05800,0.05385"
+overlay0_desc15 = "menu_toggle,0.50184,0.0605,rect,0.06476,0.06272"

--- a/overlays/GBA/portrait.cfg
+++ b/overlays/GBA/portrait.cfg
@@ -1,27 +1,24 @@
-# "name" : "Portrait GBA"
-# "author" : "Volkan Turkut"
-
 overlays = 1
-
+overlay0_name = "portrait"
 overlay0_overlay = portrait.png
-overlay0_name = portrait
+overlay0_aspect_ratio = 0.5623314
+overlay0_normalized = true
 overlay0_full_screen = true
-
-# Portrait
-
+overlay0_block_x_separation = true
+overlay0_block_y_separation = true
 overlay0_descs = 15
-overlay0_desc0  = "left,100,1300,rect,50,50"
-overlay0_desc1  = "right,280,1300,rect,50,50"
-overlay0_desc2  = "up,195,1200,rect,50,50"
-overlay0_desc3  = "down,195,1395,rect,50,50"
-overlay0_desc4 = "left|up,98,1198,rect,34,34"
-overlay0_desc5 = "left|down,98,1398,rect,34,34"
-overlay0_desc6 = "right|up,290,1200,rect,34,34"
-overlay0_desc7 = "right|down,290,1395,rect,34,34"
-overlay0_desc8 = "b,770,1330,radial,74,74"
-overlay0_desc9 = "a,965,1235,radial,74,74"
-overlay0_desc10 = "l,965,1235,radial,74,74"
-overlay0_desc11 = "r,965,1235,radial,74,74"
-overlay0_desc12  = "select,370,1585,rect,74,74"
-overlay0_desc13  = "start,570,1585,rect,74,74"
-overlay0_desc14 = "menu_toggle,205,35,rect,120,30"
+overlay0_desc0  = "left,0.09597,0.79231,rect,0.08,0.04499"
+overlay0_desc1  = "right,0.3599,0.79231,rect,0.08,0.04499"
+overlay0_desc2  = "up,0.22683,0.71826,rect,0.08,0.04499"
+overlay0_desc3  = "down,0.22683,0.86676,rect,0.08,0.04499"
+overlay0_desc4 = "left|up,0.0915,0.71556,rect,0.06,0.03374"
+overlay0_desc5 = "left|down,0.0915,0.86946,rect,0.06,0.03374"
+overlay0_desc6 = "right|up,0.36434,0.71556,rect,0.06,0.03374"
+overlay0_desc7 = "right|down,0.36434,0.86946,rect,0.06,0.03374"
+overlay0_desc8 = "b,0.64821,0.8478,radial,0.1,0.05624"
+overlay0_desc9 = "a,0.85384,0.74256,radial,0.1,0.05624"
+overlay0_desc10 = "l,0.14478,0.59946,rect,0.147,0.03044"
+overlay0_desc11 = "r,0.85224,0.59946,rect,0.147,0.03044"
+overlay0_desc12  = "select,0.422,0.95857,radial,0.05,0.02811"
+overlay0_desc13  = "start,0.58168,0.95857,radial,0.05,0.02811"
+overlay0_desc14 = "menu_toggle,0.05829,0.95856,radial,0.05,0.02811"


### PR DESCRIPTION
Created with RetroPad Editor https://valent-in.github.io/retropad-editor/
.cfg files converted to floating-point format. Background image aspect ratio should match overlay0_aspect_ratio config parameter. Actual image size does not matter (but I think it is too high)

Also this has been added to fit image and config when `auto-scale overlay` option enabled in retroarch
overlay0_block_x_separation = true
overlay0_block_y_separation = true