### PR TITLE
Fix config files for NES overlays

### DIFF
--- a/overlays/NES/edgetoedge_landscape.cfg
+++ b/overlays/NES/edgetoedge_landscape.cfg
@@ -1,25 +1,22 @@
-# "name" : "Edge to Edge Landscape NES"
-# "author" : "Volkan Turkut"
-
 overlays = 1
-
+overlay0_name = "edgetoedge_landscape"
+overlay0_aspect_ratio = 2.1650672
 overlay0_overlay = edgetoedge_landscape.png
-overlay0_name = edgetoedge_landscape
+overlay0_normalized = true
 overlay0_full_screen = true
-
-# Edge to Egde Landscape
-
+overlay0_block_x_separation = true
+overlay0_block_y_separation = true
 overlay0_descs = 13
-overlay0_desc0  = "left,100,1300,rect,50,50"
-overlay0_desc1  = "right,280,1300,rect,50,50"
-overlay0_desc2  = "up,195,1200,rect,50,50"
-overlay0_desc3  = "down,195,1395,rect,50,50"
-overlay0_desc4 = "left|up,98,1198,rect,34,34"
-overlay0_desc5 = "left|down,98,1398,rect,34,34"
-overlay0_desc6 = "right|up,290,1200,rect,34,34"
-overlay0_desc7 = "right|down,290,1395,rect,34,34"
-overlay0_desc8 = "b,770,1330,radial,74,74"
-overlay0_desc9 = "a,965,1235,radial,74,74"
-overlay0_desc10  = "select,370,1585,rect,74,74"
-overlay0_desc11  = "start,570,1585,rect,74,74"
-overlay0_desc12 = "menu_toggle,205,35,rect,120,30"
+overlay0_desc0  = "left,0.06896,0.75576,rect,0.03806,0.08128"
+overlay0_desc1  = "right,0.19382,0.75576,rect,0.03806,0.08128"
+overlay0_desc2  = "up,0.13183,0.62280,rect,0.03806,0.08128"
+overlay0_desc3  = "down,0.13183,0.88888,rect,0.03806,0.08128"
+overlay0_desc4 = "left|up,0.0664,0.61646,rect,0.02856,0.06096"
+overlay0_desc5 = "left|down,0.0664,0.8952,rect,0.02888,0.06096"
+overlay0_desc6 = "right|up,0.19730,0.61646,rect,0.02856,0.06096"
+overlay0_desc7 = "right|down,0.19730,0.89520,rect,0.02856,0.06096"
+overlay0_desc8 = "b,0.83672,0.8589,radial,0.04758,0.10160"
+overlay0_desc9 = "a,0.91877,0.68813,radial,0.04758,0.10160"
+overlay0_desc10  = "select,0.44196,0.93744,rect,0.04598,0.05128"
+overlay0_desc11  = "start,0.55728,0.93744,rect,0.04598,0.05128"
+overlay0_desc12 = "menu_toggle,0.50184,0.05761,rect,0.05135,0.05972"

--- a/overlays/NES/edgetoedge_portrait.cfg
+++ b/overlays/NES/edgetoedge_portrait.cfg
@@ -1,25 +1,22 @@
-# "name" : "Edge to Edge Portrait NES"
-# "author" : "Volkan Turkut"
-
 overlays = 1
-
+overlay0_name = "edgetoedge_portrait"
 overlay0_overlay = edgetoedge_portrait.png
-overlay0_name = edgetoedge_portrait
+overlay0_aspect_ratio = 0.4618794
+overlay0_normalized = true
 overlay0_full_screen = true
-
-# Edge to Egde Portrait
-
+overlay0_block_x_separation = true
+overlay0_block_y_separation = true
 overlay0_descs = 13
-overlay0_desc0  = "left,100,1300,rect,50,50"
-overlay0_desc1  = "right,280,1300,rect,50,50"
-overlay0_desc2  = "up,195,1200,rect,50,50"
-overlay0_desc3  = "down,195,1395,rect,50,50"
-overlay0_desc4 = "left|up,98,1198,rect,34,34"
-overlay0_desc5 = "left|down,98,1398,rect,34,34"
-overlay0_desc6 = "right|up,290,1200,rect,34,34"
-overlay0_desc7 = "right|down,290,1395,rect,34,34"
-overlay0_desc8 = "b,770,1330,radial,74,74"
-overlay0_desc9 = "a,965,1235,radial,74,74"
-overlay0_desc10  = "select,370,1585,rect,74,74"
-overlay0_desc11  = "start,570,1585,rect,74,74"
-overlay0_desc12 = "menu_toggle,205,35,rect,120,30"
+overlay0_desc0  = "left,0.14034,0.771,rect,0.07111,0.03284"
+overlay0_desc1  = "right,0.37542,0.771,rect,0.07111,0.03284"
+overlay0_desc2  = "up,0.25788,0.71696,rect,0.07111,0.03284"
+overlay0_desc3  = "down,0.25788,0.82563,rect,0.07111,0.03284"
+overlay0_desc4 = "left|up,0.13445,0.71474,rect,0.05332,0.02463"
+overlay0_desc5 = "left|down,0.13445,0.82785,rect,0.05332,0.02463"
+overlay0_desc6 = "right|up,0.37986,0.71474,rect,0.05332,0.02463"
+overlay0_desc7 = "right|down,0.37986,0.82785,rect,0.05332,0.02463"
+overlay0_desc8 = "b,0.61938,0.76575,radial,0.08889,0.04105"
+overlay0_desc9 = "a,0.84337,0.76575,radial,0.08889,0.04105"
+overlay0_desc10  = "select,0.3976,0.90800,rect,0.06,0.01478"
+overlay0_desc11  = "start,0.60164,0.90800,rect,0.06,0.01478"
+overlay0_desc12 = "menu_toggle,0.86998,0.68147,rect,0.06,0.01478"

--- a/overlays/NES/landscape.cfg
+++ b/overlays/NES/landscape.cfg
@@ -1,25 +1,22 @@
-# "name" : "NES"
-# "author" : "Volkan Turkut"
-
 overlays = 1
-
+overlay0_name = "landscape"
+overlay0_aspect_ratio = 1.7786308
 overlay0_overlay = landscape.png
-overlay0_name = landscape
+overlay0_normalized = true
 overlay0_full_screen = true
-
-# Landscape
-
+overlay0_block_x_separation = true
+overlay0_block_y_separation = true
 overlay0_descs = 13
-overlay0_desc0  = "left,100,1300,rect,50,50"
-overlay0_desc1  = "right,280,1300,rect,50,50"
-overlay0_desc2  = "up,195,1200,rect,50,50"
-overlay0_desc3  = "down,195,1395,rect,50,50"
-overlay0_desc4 = "left|up,98,1198,rect,34,34"
-overlay0_desc5 = "left|down,98,1398,rect,34,34"
-overlay0_desc6 = "right|up,290,1200,rect,34,34"
-overlay0_desc7 = "right|down,290,1395,rect,34,34"
-overlay0_desc8 = "b,770,1330,radial,74,74"
-overlay0_desc9 = "a,965,1235,radial,74,74"
-overlay0_desc10  = "select,370,1585,rect,74,74"
-overlay0_desc11  = "start,570,1585,rect,74,74"
-overlay0_desc12 = "menu_toggle,205,35,rect,120,30"
+overlay0_desc0  = "left,0.06050,0.75576,rect,0.04570,0.08128"
+overlay0_desc1  = "right,0.21353,0.75576,rect,0.04570,0.08128"
+overlay0_desc2  = "up,0.13750,0.62280,rect,0.04570,0.08128"
+overlay0_desc3  = "down,0.13750,0.88888,rect,0.04570,0.08128"
+overlay0_desc4 = "left|up,0.05829,0.61646,rect,0.03553,0.06096"
+overlay0_desc5 = "left|down,0.05829,0.8952,rect,0.03553,0.06096"
+overlay0_desc6 = "right|up,0.21796,0.61646,rect,0.03553,0.06096"
+overlay0_desc7 = "right|down,0.21796,0.89520,rect,0.03553,0.06096"
+overlay0_desc8 = "b,0.82341,0.8589,radial,0.05712,0.10160"
+overlay0_desc9 = "a,0.92099,0.68813,radial,0.05712,0.10160"
+overlay0_desc10  = "select,0.42865,0.93744,rect,0.05720,0.05128"
+overlay0_desc11  = "start,0.57059,0.93744,rect,0.05720,0.05128"
+overlay0_desc12 = "menu_toggle,0.50184,0.05761,rect,0.06389,0.05972"

--- a/overlays/NES/portrait.cfg
+++ b/overlays/NES/portrait.cfg
@@ -1,25 +1,22 @@
-# "name" : "Portrait NES"
-# "author" : "Volkan Turkut"
-
 overlays = 1
-
+overlay0_name = "portrait"
 overlay0_overlay = portrait.png
-overlay0_name = portrait
+overlay0_aspect_ratio = 0.5625
+overlay0_normalized = true
 overlay0_full_screen = true
-
-# Portrait
-
+overlay0_block_x_separation = true
+overlay0_block_y_separation = true
 overlay0_descs = 13
-overlay0_desc0  = "left,100,1300,rect,50,50"
-overlay0_desc1  = "right,280,1300,rect,50,50"
-overlay0_desc2  = "up,195,1200,rect,50,50"
-overlay0_desc3  = "down,195,1395,rect,50,50"
-overlay0_desc4 = "left|up,98,1198,rect,34,34"
-overlay0_desc5 = "left|down,98,1398,rect,34,34"
-overlay0_desc6 = "right|up,290,1200,rect,34,34"
-overlay0_desc7 = "right|down,290,1395,rect,34,34"
-overlay0_desc8 = "b,770,1330,radial,74,74"
-overlay0_desc9 = "a,965,1235,radial,74,74"
-overlay0_desc10  = "select,370,1585,rect,74,74"
-overlay0_desc11  = "start,570,1585,rect,74,74"
-overlay0_desc12 = "menu_toggle,205,35,rect,120,30"
+overlay0_desc0  = "left,0.13844,0.76227,rect,0.07111,0.03999"
+overlay0_desc1  = "right,0.37303,0.76227,rect,0.07111,0.03999"
+overlay0_desc2  = "up,0.25476,0.69643,rect,0.07111,0.03999"
+overlay0_desc3  = "down,0.25476,0.82843,rect,0.07111,0.03999"
+overlay0_desc4 = "left|up,0.13445,0.69403,rect,0.05332,0.02999"
+overlay0_desc5 = "left|down,0.13445,0.83083,rect,0.05332,0.02999"
+overlay0_desc6 = "right|up,0.37699,0.69403,rect,0.05332,0.02999"
+overlay0_desc7 = "right|down,0.37699,0.83083,rect,0.05332,0.02999"
+overlay0_desc8 = "b,0.61938,0.75466,radial,0.08889,0.04999"
+overlay0_desc9 = "a,0.84337,0.75466,radial,0.08889,0.04999"
+overlay0_desc10  = "select,0.63712,0.89216,rect,0.06,0.018"
+overlay0_desc11  = "start,0.82563,0.89216,rect,0.06,0.018"
+overlay0_desc12 = "menu_toggle,0.1226,0.94539,rect,0.06,0.018"


### PR DESCRIPTION
Controls placed a bit differently compared to GBA overlays so same configs can not be used. What is the reason of shifting dpad in landscape modes which differs only in color?